### PR TITLE
Expose REST ports on lnd and lnd2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,7 @@ services:
     ports:
       - "9735" # p2p
       - "30009:10009" # grpc
+      - "4000:8080" # rest
 
   lnd2:
     container_name: lnd2
@@ -111,6 +112,7 @@ services:
     ports:
       - "9735" # p2p
       - "30010:10009" # grpc
+      - "4001:8080" # rest
 
   lnd-15-1:
     container_name: lnd-15-1

--- a/resources/lnd.conf
+++ b/resources/lnd.conf
@@ -3,6 +3,7 @@ debuglevel=debug
 noseedbackup=1
 alias=elsewhere
 rpclisten=0.0.0.0
+restlisten=0.0.0.0
 maxpendingchannels=10
 accept-keysend=true
 accept-amp=true


### PR DESCRIPTION
Exposing REST ports `4000` and `4001` on `lnd` and `lnd2`, respectively, so we can regtest with more apps!

Thanks @tee8z for helping.